### PR TITLE
Update projectVerification.md

### DIFF
--- a/dapps/projectVerification.md
+++ b/dapps/projectVerification.md
@@ -15,14 +15,14 @@ This document serves as a guide to understanding the Project Verification proces
 - Build deeper trust and transparency with Donors.
 - Make your Project stand out.
 - Get listed as a ‘Verified Project’ on our platform and searchable by that category.
-- Become eligible for our GIVbacks program, which rewards Givers for philanthropic donations. Once your project is verified, the supporters who donate to your project will be rewarded with GIV tokens which they can use to participate in the GIVeconomy. As a Project, participation in the GIVbacks program will greatly increase your likelihood of receiving donations.
+- Become eligible for our GIVbacks program, which rewards Givers for philanthropic donations. Once your project is verified, the supporters who donate to your project will be rewarded with GIV tokens which they can use to participate in the GIVeconomy. Participation in the GIVbacks program will greatly increase the likelihood of your project receiving donations.
 *Note that verified Project addresses will not receive GIV for donations made to their own project or other verified projects.*
 
 ## Qualifying Measures for Project Verification
 
 The verification process will require some additional information about a project and the intended impact of the organization.
 
-Projects must submit their application forms at least one week before the start of a round in order to qualify for that round. Once approved, a project will be qualified to participate in all subsequent GIVbacks rounds. When a project becomes verified, its status is updated on Giveth and it is given a `Verified` badge on the Homepage and on the Project's Page.
+Projects must submit their application forms at least one week before the start of a round in order to qualify for that round. Once approved, a project will be qualified to participate in all subsequent GIVbacks rounds. When a project becomes verified, its status is updated on Giveth, and it is given a `Verified` badge on the Homepage and on the Projects Page.
 
 <img alt="GIVbacks Rounds Schedule" src={useBaseUrl('img/content/givBacksRounds.png')} />
 
@@ -30,33 +30,33 @@ Here is the information you will need to provide in the application:
 
 1. Your full name
 2. Your email address
-3. Links and/or usernames to the social media accounts that are owned by both you and the organization. eg. Twitter, Github, Discord, Facebook etc.
+3. Links and/or usernames to the social media accounts that are owned by both you and the organization. eg. Twitter, Github, Discord, Facebook, etc.
 4. The name of your project
-5. A link to your Giveth.io project page.
-6. Information about the history of your project. eg. when it was founded, which milestones your organization/project has achieved since conception, etc. Please provide links to photos, videos, testimonials or other evidence of your project's impact.
-7. The funds raised are expected to be used for public benefit and not for personal gain - Giveth will need to know how you will use the funds that your project raises. We are looking for detailed funding goals as well as an overall roadmap / action plan of the project.
+5. A link to your Giveth.io project page
+6. Information about the history of your project, e.g., when it was founded, which milestones your organization/project has achieved since conception, etc. Please provide links to photos, videos, testimonials or other evidence of your project's impact.
+7. The funds raised are expected to be used for public benefit and not for personal gain - Giveth will need to know how you will use the funds that your project raises. We are looking for detailed funding goals as well as an overall roadmap/action plan of the project.
 8. A list of all wallet addresses used for managing funds within your project.
-9. In order to ensure that you are actually a representative of the project you're applying for, we ask that you post/share a link to your Giveth project **from the organization's twitter or social media account.** You will need to provide a link to the twitter or social media post.
+9. In order to ensure that you are actually a representative of the project you're applying for, we ask that you post/share a link to your Giveth project **from the organization's Twitter or social media account.** You will need to provide a link to the Twitter or social media post.
 10. Confirm “Yes”: We pledge that funds raised will be used for public benefit, not for personal gain.
 11. Confirm “Yes”: We understand Giveth will be analyzing all donations looking for fraud or abuse. If Giveth has any reason to suspect abuse, we understand our donors may not receive any GIVbacks and that Giveth may share any evidence of fraud publicly.
-12. Confirm “Yes”: We will only accept new, external donations through Giveth, and we understand that if we are found to be recirculating our own funds through Giveth this will be considered abuse of the system.
+12. Confirm “Yes”: We will only accept new, external donations through Giveth, and we understand that if we are found to be recirculating our own funds through Giveth, this will be considered abuse of the system.
 13. Confirm “Yes”: We understand our donation data will be reviewed, and if it seems like in any way we are abusing the system, our donors will not receive GIVbacks, and we will lose our verified status.
 14. Our goal is to ensure there is no fraudulent use of GIVbacks. We will need to know what reputation is at stake for you and/or your project if you were to be found participating in malicious activity. *Please provide links to proof of reputation if available.
-15. If your project is part of a registered non-profit organization, you will need to upload documentation to prove your registered status. Having obtained non-profit status is not a requirement but it is helpful for the verification process.
+15. If your project is part of a registered non-profit organization, you will need to upload documentation to prove your registered status. Having obtained non-profit status is not a requirement, but it is helpful for the verification process.
 16. If your project is not a registered non-profit, the team will need to know how your organization is structured.
 
 If you are a project owner who would like to apply to receive a `Verified` badge, encourage more Givers and also give back to those who have helped you reach your goals, please [fill out this form](https://giveth.typeform.com/verification).
 
 ## Disqualifying Factors for the GIVbacks Program
 
-Once a GIVbacks round ends, there is a period of time allocated for our team to review flagged projects and donations for disqualifying factors before GIV is distributed to donors. A project could have their Verified status revoked if any of these factors are found. Donors to projects who are found with any of the following activity may also be denied GIVbacks for that round. Disqualify factors are as follows:
+Once a GIVbacks round ends, there is a period of time allocated for our team to review flagged projects and donations for disqualifying factors before GIV is distributed to donors. A project could have their Verified status revoked if any of these factors are found. Donors to projects who are found with any of the following activity may also be denied GIVbacks for that round. Disqualification factors are as follows:
 
-1. **Giving/offering goods or services to donors in exchange for their donation.** A project owner cannot offer goods such as a sponsorship for a conference, girl scout cookie purchases or tickets for a dinner, even if the proceeds go to charity. Project owners cannot provide services like acting as a crypto exchange for their donors. They can explain how to use an exchange, but they cannot convert the money for their donors.
+1. **Giving/offering goods or services to donors in exchange for their donation.** A project owner cannot offer goods such as a sponsorship for a conference, Girl Scout cookie purchases or tickets for a dinner, even if the proceeds go to charity. Project owners cannot provide services like acting as a crypto exchange for their donors. They can explain how to use an exchange, but they cannot convert the money for their donors.
 2. **Circulating donations raised by other means.** Only “first touch” donations count for GIVbacks. If a project receives funding from a donor and is found to be circulating these donations within the Giveth platform to receive GIVbacks, they will be disqualified. For example, a project should not be sending fiat donations received elsewhere back to their donors and asking them to donate on Giveth with crypto.
 3. **The funds are not being used for what is expressed in the project page or submitted verification application.** Verified projects are responsible for keeping their projects up-to-date with information on how the funds are being used. If the project states explicitly that they are, for example, using the funds to develop education programs but are found to be using the funds to employ developers, they may be disqualified from the GIVbacks program.
-4. **Unscrupulous or fraudulent activity.** This can be the use of violence, breaking laws, or other behaviour that does not uphold the values of the Giveth community. Projects found to be violating our Terms and Conditions will not only lose their verification status, but also will be canceled.
+4. **Unscrupulous or fraudulent activity.** This can be the use of violence, breaking laws, or other behaviour that does not uphold the values of the Giveth community. Projects found to be violating our Terms and Conditions will not only lose their verification status, but they also will be canceled.
 
-The Giveth Project Verification team is responsible for monitoring GIVbacks activity and the Project Verification system, and will ultimately use their discretion to determine whether a project’s actions are unscrupulous and/or disqualifying.
+The Giveth Project Verification team is responsible for monitoring GIVbacks activity and the Project Verification system and will ultimately use their discretion to determine whether a project’s actions are unscrupulous and/or disqualifying.
 
 ## Graduated Sanctions for flagged projects
 


### PR DESCRIPTION
Is there a Giveth « Projects Page »? On this page it was stated that approved projects will be on the Giveth homepage (« h » shouldn’t be capital but I left it for now) and on « the Project’s Page ». If that is referring to a Giveth page, it should not have an apostrophe. If it is referring to the project’s page itself (that is to say, of the project), it should not be capitalized. Thanks!